### PR TITLE
feat: サプライチェーン攻撃対策のクールダウン期間を導入

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,10 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    # サプライチェーン攻撃対策: 公開直後の取り込みを避けるクールダウン期間
+    # cf. https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#cooldown--
+    cooldown:
+      default-days: 7
+      semver-major-days: 14
+      semver-minor-days: 7
+      semver-patch-days: 3

--- a/.github/workflows/github-actions-lint-update.yml
+++ b/.github/workflows/github-actions-lint-update.yml
@@ -36,6 +36,18 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Load cooldown days from dependabot.yml
+        # サプライチェーン攻撃対策のクールダウン値は dependabot.yml を単一情報源とする
+        # （Dependabotサービスは変数展開・外部参照を一切サポートしないため、リテラル値を持つdependabot.ymlを真とし、本workflowが読み取り側になる）
+        id: cooldown
+        run: |
+          days=$(yq '.updates[0].cooldown.default-days' .github/dependabot.yml)
+          if [ -z "${days}" ] || [ "${days}" = "null" ]; then
+            echo "ERROR: cooldown.default-days not found in .github/dependabot.yml" >&2
+            exit 1
+          fi
+          echo "days=${days}" >> "${GITHUB_OUTPUT}"
+
       - name: Get Environment Names
         id: get-env-names
         env:
@@ -113,32 +125,49 @@ jobs:
           BINARY_VERSION_ENV_NAME: ${{ steps.get-env-names.outputs.version }}
           BINARY_CHECKSUM: ${{ steps.get-binary-info.outputs.checksum }}
           BINARY_CHECKSUM_ENV_NAME: ${{ steps.get-env-names.outputs.checksum }}
+          COOLDOWN_DAYS: ${{ steps.cooldown.outputs.days }}
         with:
           result-encoding: string
           script: |
+            const COOLDOWN_DAYS = parseInt(process.env.COOLDOWN_DAYS, 10);
+            if (Number.isNaN(COOLDOWN_DAYS)) {
+              core.setFailed('COOLDOWN_DAYS is not a valid number');
+              return 'true';
+            }
             const currentVersion = process.env.BINARY_VERSION;
-            const latestVersion = await github.rest.repos.getLatestRelease({
+            const release = await github.rest.repos.getLatestRelease({
               owner: process.env.BINARY_OWNER,
               repo: process.env.BINARY_REPO
-            }).then(({ data }) => {
-              return data.tag_name.replace(/^v/, '');
             });
+            const latestVersion = release.data.tag_name.replace(/^v/, '');
+            const publishedAt = new Date(release.data.published_at);
+            const ageDays = (Date.now() - publishedAt.getTime()) / (1000 * 60 * 60 * 24);
             console.log('currentVersion:', currentVersion);
             console.log('latestVersion:', latestVersion);
+            console.log('publishedAt:', release.data.published_at);
+            console.log('ageDays:', ageDays.toFixed(2));
             core.setOutput('currentVersion', currentVersion);
             core.setOutput('latestVersion', latestVersion);
-            const result = currentVersion === latestVersion ? 'true' : 'false';
-            if (result === 'false') {
-              const checkSumsTxtUrl = `https://github.com/${process.env.BINARY_OWNER}/${process.env.BINARY_REPO}/releases/download/v${latestVersion}/${process.env.BINARY_NAME}_${latestVersion}_checksums.txt`;
-              console.log('checkSumsTxtUrl:', checkSumsTxtUrl);
-              const response = await fetch(checkSumsTxtUrl);
-              const text = await response.text();
-              console.log('Checksums file content:', text);
-              const checksum = text.split("\n").find((line) => line.includes("linux_amd64")).split(" ")[0];
-              console.log('checksum:', checksum);
-              core.setOutput('checksum', checksum);
+
+            if (currentVersion === latestVersion) {
+              return 'true';
             }
-            return result;
+
+            // サプライチェーン攻撃対策: 公開直後のリリースは取り込まない
+            if (ageDays < COOLDOWN_DAYS) {
+              console.log(`Cooldown active: release ${ageDays.toFixed(2)} days old (< ${COOLDOWN_DAYS}). Skip.`);
+              return 'true';
+            }
+
+            const checkSumsTxtUrl = `https://github.com/${process.env.BINARY_OWNER}/${process.env.BINARY_REPO}/releases/download/v${latestVersion}/${process.env.BINARY_NAME}_${latestVersion}_checksums.txt`;
+            console.log('checkSumsTxtUrl:', checkSumsTxtUrl);
+            const response = await fetch(checkSumsTxtUrl);
+            const text = await response.text();
+            console.log('Checksums file content:', text);
+            const checksum = text.split("\n").find((line) => line.includes("linux_amd64")).split(" ")[0];
+            console.log('checksum:', checksum);
+            core.setOutput('checksum', checksum);
+            return 'false';
       - name: Update env to github_actions_lint.yml
         if: steps.check-binary-version.outputs.result == 'false'
         env:

--- a/scripts/linux/install.sh
+++ b/scripts/linux/install.sh
@@ -75,8 +75,7 @@ cd "${ROOT_DIR}" && pre-commit install
 ## Claude Code
 curl -fsSL https://claude.ai/install.sh | bash
 
-# npx --yes cc-sdd@latest --claude --lang ja
-npx --yes cc-sdd@3.0.2 --claude-agent --lang ja
+npx --yes cc-sdd@3.0.2 --claude-skills --lang ja
 
 ## vde-layout (requires Node.js 22+)
 npm install -g vde-layout

--- a/scripts/linux/install.sh
+++ b/scripts/linux/install.sh
@@ -75,8 +75,8 @@ cd "${ROOT_DIR}" && pre-commit install
 ## Claude Code
 curl -fsSL https://claude.ai/install.sh | bash
 
-# npx --yes cc-sdd@latest --claude --lang ja 
-npx --yes cc-sdd@latest --claude-agent --lang ja
+# npx --yes cc-sdd@latest --claude --lang ja
+npx --yes cc-sdd@3.0.2 --claude-agent --lang ja
 
 ## vde-layout (requires Node.js 22+)
 npm install -g vde-layout


### PR DESCRIPTION
## Summary
- アップデート公開直後の取り込みを避けるクールダウン期間を導入し、サプライチェーン攻撃の影響を時間的に遮断する
- `dependabot.yml` を真の単一情報源とし、GHA workflow は `yq` で実行時読取（マジックナンバー二重管理の回避）
- `cc-sdd` を `@latest` から固定バージョン `3.0.2` にpin

## 変更内容
- `.github/dependabot.yml`: `cooldown` ブロック追加（default-days: 7 / semver-major-days: 14 / semver-minor-days: 7 / semver-patch-days: 3）
- `.github/workflows/github-actions-lint-update.yml`:
  - `Load cooldown days from dependabot.yml` step追加（`yq` でcooldown値抽出）
  - `Check Binary Version` step を改修: `published_at` ベースで cooldown 期間中はスキップ
  - `env: COOLDOWN_DAYS: 7` を削除（dependabot.yml が単一情報源に）
- `scripts/linux/install.sh`: `npx cc-sdd@latest` → `npx cc-sdd@3.0.2`

## 参考
- [サプライチェーン攻撃の対策 (kawasima/scrapbox)](https://scrapbox.io/kawasima/%E3%82%B5%E3%83%97%E3%83%A9%E3%82%A4%E3%83%81%E3%82%A7%E3%83%BC%E3%83%B3%E6%94%BB%E6%92%83%E3%81%AE%E5%AF%BE%E7%AD%96)
- [Dependabot cooldown オプションリファレンス](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#cooldown--)

## Test plan
- [ ] PR上で \`actionlint\` / \`ghalint\` / \`zizmor\` の lint がgreen
- [ ] \`workflow_dispatch\` で \`github-actions-lint-update.yml\` を手動実行し、\`Load cooldown days from dependabot.yml\` step が \`days=7\` を出力することを確認
- [ ] 同workflow実行ログで \`ageDays\` / cooldown判定ログが出力されることを確認
- [ ] dependabot.yml の \`cooldown.default-days\` を一時的に消したブランチで実行 → workflow が \`exit 1\` で fail することを確認（任意）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **Chores**
  * Dependabot の更新設定にクールダウン期間を追加（default/semver-major/semver-minor/semver-patch）
  * ワークフローを更新しクールダウンを読み取ってリリース年齢に応じてバイナリ更新を抑制
  * インストーラースクリプトで Claude Code を v3.0.2 に固定し起動フラグを変更

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/allllllllez/dotfiles/pull/59?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->