### PR TITLE
feat: WSL2メモリ設定(.wslconfig)をdotfilesで管理

### DIFF
--- a/HOME/.wslconfig
+++ b/HOME/.wslconfig
@@ -1,0 +1,10 @@
+[wsl2]
+# Windows側のメモリ逼迫を防ぐため、WSLのメモリ上限を8GBに制限
+# (32GB RAMマシンで16GB割当は過剰であり、本体の運用に支障をきたしたため。。。)
+memory=8GB
+swap=4GB
+networkingMode=mirrored
+
+# WSL2はデフォルトでページキャッシュを保持し続け、Windowsにメモリを返却しない
+# gradual を設定すると、不要になったキャッシュを段階的にWindowsへ返却する
+autoMemoryReclaim=gradual

--- a/HOME/.wslconfig
+++ b/HOME/.wslconfig
@@ -3,6 +3,7 @@
 # (32GB RAMマシンで16GB割当は過剰であり、本体の運用に支障をきたしたため。。。)
 memory=8GB
 swap=4GB
+# 某 VPN 接続中にWSL2から外部アクセスするために mirored を指定。Rancher 使用時はコンテナ上のStreamlitにアクセスできないためコメントアウト
 networkingMode=mirrored
 
 # WSL2はデフォルトでページキャッシュを保持し続け、Windowsにメモリを返却しない

--- a/HOME/AppData/Local/Packages/Microsoft.WindowsTerminal_8wekyb3d8bbwe/LocalState/settings.json
+++ b/HOME/AppData/Local/Packages/Microsoft.WindowsTerminal_8wekyb3d8bbwe/LocalState/settings.json
@@ -21,12 +21,12 @@
             "keys": "ctrl+c"
         },
         {
-            "id": "Terminal.FindText",
-            "keys": "ctrl+shift+f"
-        },
-        {
             "id": "Terminal.PasteFromClipboard",
             "keys": "ctrl+v"
+        },
+        {
+            "id": "Terminal.FindText",
+            "keys": "ctrl+shift+f"
         },
         {
             "id": "Terminal.DuplicatePaneAuto",
@@ -47,7 +47,7 @@
     {
         "defaults": 
         {
-            "colorScheme": "Campbell",
+            "colorScheme": "One Half Dark",
             "font": 
             {
                 "face": "PlemolJP Console NF"
@@ -56,6 +56,7 @@
         "list": 
         [
             {
+                "colorScheme": "One Half Dark",
                 "commandline": "ubuntu.exe",
                 "cursorShape": "filledBox",
                 "guid": "{438aad1b-cfd7-4984-8056-87c43f4d4cfa}",


### PR DESCRIPTION
## 概要
WSL2のメモリ設定ファイル(.wslconfig)をdotfilesリポジトリで管理する。
メモリ逼迫の再発防止のため、設定意図をコメントで記録。

## 変更内容
- `HOME/.wslconfig` を新規追加
  - `memory=8GB`: Windows側のメモリ逼迫を防ぐため16GB→8GBに制限
  - `autoMemoryReclaim=gradual`: WSL2がページキャッシュをWindowsに自動返却する設定
  - `networkingMode=mirrored`: ミラーモード(既存設定の引き継ぎ)

## 備考
- 現状、Windows側のシンボリックリンク作成には管理者権限 or 開発者モードが必要なため、配置は手動コピーで対応
- 配置先: `C:\Users\<ユーザー名>\.wslconfig`
- 設定反映にはWSL再起動(`wsl --shutdown`)が必要

## チェックリスト
- [x] コードレビューが完了している
- [ ] テストが実装されている
- [x] ドキュメントが更新されている（必要な場合）
- [x] パフォーマンスへの影響を考慮した

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * WSL2 のメモリを8GB、スワップを4GBに制限し、ネットワークをミラーリングモードに設定しました。
  * 不要なページキャッシュを段階的に解放する設定を追加しました。

* **設定変更**
  * Windows Terminal の既定カラースキームを「One Half Dark」に変更しました。
  * 貼り付けと検索のキーバインド設定を整理しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->